### PR TITLE
Update Toolbox to v3.1.6

### DIFF
--- a/vapor.rb
+++ b/vapor.rb
@@ -1,8 +1,8 @@
 class Vapor < Formula
   homepage "https://vapor.codes"
-  version "3.1.4.l"
+  version "3.1.6"
   url "https://github.com/vapor/toolbox/releases/download/3.1.4/macOS-sierra.tar.gz"
-  sha256 "49f987fd12f493600e7989c63dda0b2c5f68c4b261ecc7042ccf1b2e75e53732"
+  sha256 "7fdf23f9439c0b04bf932c7348e2288b8eac1888ece242652470fd9bd5b65bc5"
 
   depends_on "ctls" => :run
   depends_on "libressl" => :run


### PR DESCRIPTION
Run https://github.com/vapor/toolbox/blob/master/distribute.sh

Missing: Attach macOS-sierra.tar.gz to https://github.com/vapor/toolbox/releases/tag/3.1.6