### PR TITLE
Fix mv step in vapor-beta formula

### DIFF
--- a/vapor-beta.rb
+++ b/vapor-beta.rb
@@ -14,7 +14,7 @@ class VaporBeta < Formula
 
   def install
     system "swift", "build", "--disable-sandbox"
-    system "mv", ".build/debug/Executable", "vapor-beta"
+    system "mv", ".build/debug/vapor", "vapor-beta"
     bin.install "vapor-beta"
   end
 


### PR DESCRIPTION
Fixes #23 

The formula's `swift build --disable-sandbox` install step produces a `.build/debug/vapor` instead of a `.build/debug/Executable` causing the `mv` step to fail because `.build/debug/Executable` doesn't exist.

This PR fixes it by specifying the correct path in the `mv` step.