### PR TITLE
OpenSSL is no longer a dependency to build Vapor 4 🎉

### DIFF
--- a/vapor-beta.rb
+++ b/vapor-beta.rb
@@ -4,7 +4,6 @@ class VaporBeta < Formula
   head "https://github.com/vapor/toolbox.git"
 
   depends_on :xcode => "11"
-  depends_on "openssl"
 
   stable do
     version "18.0.0-beta.27"


### PR DESCRIPTION
This PR is dependent on vapor/vapor#2166 and kylebrowning/APNSwift#85 being merged before we can merge this