### PR TITLE
Release toolbox 18 beta 29

### DIFF
--- a/vapor-beta.rb
+++ b/vapor-beta.rb
@@ -6,14 +6,14 @@ class VaporBeta < Formula
   depends_on :xcode => "11"
 
   stable do
-    version "18.0.0-beta.27"
+    version "18.0.0-beta.29"
     url "https://github.com/vapor/toolbox/archive/#{version}.tar.gz"
-    sha256 "3f031f885fc4cfac9cabb6cb86124ad1283cd75ce58bc5804774c04af45e6d03"
+    sha256 "5b782e4c74f5a37c3dc2c353e7cfe099612ea88d08201d4547fc981106bdf03d"
   end
 
   def install
-    system "swift", "build", "--disable-sandbox"
-    system "mv", ".build/debug/vapor", "vapor-beta"
+    system "swift", "build", "--disable-sandbox", "-c", "release", "-Xswiftc", "-cross-module-optimization"
+    system "mv", ".build/release/vapor", "vapor-beta"
     bin.install "vapor-beta"
   end
 


### PR DESCRIPTION
- Update Homebrew formula for `vapor-beta` to toolbox version `18.0.0-beta.29`.
   See https://github.com/vapor/toolbox/releases/tag/18.0.0-beta.29.

- When installing `vapor-beta`, build with Release configuration.